### PR TITLE
switch associations to colors

### DIFF
--- a/api.py
+++ b/api.py
@@ -34,27 +34,29 @@ def readme():
     return markdown_str
 
 
-@app.route("/clues")
-def get_clues():
-    positive = parse_query_list("positive")
-    negative = parse_query_list("negative")
-    neutral = parse_query_list("neutral")
-    assassin = parse_query_param("assassin")
+@app.route("/clues/<color>")
+def get_clues(color):
+    if not color.lower() in ("red", "blue"):
+        abort(400, description="Invalid color. Must be 'red' or 'blue'")
+    reds = parse_query_list("red")
+    blues = parse_query_list("blue")
+    tans = parse_query_list("tan")
+    black = parse_query_param("black")
     num = parse_query_param("num", 10, int)
-    board = CodenamesBoard(positive, negative, neutral, assassin)
+    board = CodenamesBoard(reds, blues, tans, black)
     if not board.board():
         abort(400, description="Missing required query parameter. "
                                "At least one of 'positive', 'negative', 'neutral', 'assassin' required.")
     model = NLPModel()
-    return model.generate_valid_clues(board, num)
+    return model.generate_valid_clues(board, num, color.lower())
 
 
-@app.route("/clues/<word>")
+@app.route("/words/<word>")
 def get_clues_for_word(word):
     num = parse_query_param("num", 10, int)
     model = NLPModel()
-    board = CodenamesBoard(positive=[word])
-    return model.generate_valid_clues(board, num)
+    board = CodenamesBoard(red=[word])
+    return model.generate_valid_clues(board, num, color="red")
 
 
 @app.route("/words")

--- a/codenames_board.py
+++ b/codenames_board.py
@@ -1,27 +1,41 @@
 from typing import Optional
 
-WordScoresDict = dict[str, float]
-
 
 class CodenamesBoard:
-    def __init__(self, positive: Optional[list[str]] = None, negative: Optional[list[str]] = None,
-                 neutral: Optional[list[str]] = None, assassin: Optional[str] = None):
-        self.positive = positive or []
-        self.negative = negative or []
-        self.neutral = neutral or []
-        self.assassin = assassin
+    def __init__(self, red: Optional[list[str]] = None, blue: Optional[list[str]] = None,
+                 tan: Optional[list[str]] = None, black: Optional[str] = None):
+        self.red = red or []
+        self.blue = blue or []
+        self.neutral = tan or []
+        self.assassin = black
 
     def __repr__(self):
-        return f"{self.positive}\n{self.negative}\n{self.neutral}\n{self.assassin}"
+        return f"{self.red}\n{self.blue}\n{self.neutral}\n{self.assassin}"
 
     def has_assassin(self) -> bool:
         return self.assassin is not None
 
     def board(self) -> list[str]:
-        return self.positive + self.negative + self.neutral + ([self.assassin] if self.has_assassin() else [])
+        return self.red + self.blue + self.neutral + ([self.assassin] if self.has_assassin() else [])
 
-    def negative_associated(self) -> list[str]:
-        return self.negative + self.neutral + ([self.assassin] if self.has_assassin() else [])
+    def positive(self, color: str) -> list[str]:
+        if color == "red":
+            return self.red
+        elif color == "blue":
+            return self.blue
+        else:
+            raise ValueError("color must be 'red' or 'blue'")
+
+    def negative(self, color: str) -> list[str]:
+        words = []
+        if color == "red":
+            words.extend(self.blue)
+        elif color == "blue":
+            words.extend(self.red)
+        else:
+            raise ValueError("color must be 'red' or 'blue'")
+
+        return words + self.neutral + ([self.assassin] if self.has_assassin() else [])
 
     def is_valid_clue(self, clue: str) -> bool:
         if not clue.isalpha():

--- a/nlp_model.py
+++ b/nlp_model.py
@@ -9,17 +9,22 @@ class NLPModel:
     def __init__(self):
         self.model = KeyedVectors.load(f'models/saved-vectors')
 
-    def generate_similar_words(self, board: CodenamesBoard, num: int):
+    def generate_similar_words(self, board: CodenamesBoard, num: int, color: str):
         """given a Codenames board, returns the most similar words, regardless of validity"""
-        return self.model.most_similar(positive=board.positive, negative=board.negative_associated(), topn=num)
+        assert color in ("red", "blue")
 
-    def generate_valid_clues(self, board: CodenamesBoard, num: int) -> WordScoresDict:
+        return self.model.most_similar(positive=board.positive(color), negative=board.negative(color), topn=num)
+
+    def generate_valid_clues(self, board: CodenamesBoard, num: int, color: str) -> WordScoresDict:
         """given a Codenames board, returns the most similar valid clues"""
+        assert color in ("red", "blue")
+
         temp = num
         while True:
-            words = self.generate_similar_words(board, temp)
+            words = self.generate_similar_words(board, temp, color)
             valid_clues = [(word, score) for (word, score) in words if board.is_valid_clue(word)]
             if len(valid_clues) == num:
                 break
             temp += 1
+
         return {clue.lower(): score for clue, score in valid_clues}


### PR DESCRIPTION
Refactored the `/clues` route to `/clues/<color>`, and required query parameters from `[positive, negative, neutral, assassin]` to `[red, blue, tan, black]`. The `CodenamesBoard` now takes a color to return the positively and negatively associated words.

As a consequence to the above, the `/clues/<word>` route had to be renamed to `/words/<word>`